### PR TITLE
fix(bcrypt):password max 64 byte

### DIFF
--- a/client/src/api/users.ts
+++ b/client/src/api/users.ts
@@ -81,7 +81,8 @@ export const useGetUserQuery = () => {
 export const updatePasswordSchema = z
   .object({
     username: z.string().optional(),
-    password: z.string().min(8, "Password must be at least 8 characters"),
+    // max 64 to avoid bcrypt 72 bytes limit issues
+    password: z.string().min(8, "Password must be at least 8 characters").max(64, "Password cannot exceed 64 characters"),
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {

--- a/client/src/app/pages/settings/index.tsx
+++ b/client/src/app/pages/settings/index.tsx
@@ -47,7 +47,11 @@ const updatePasswordSchema = z
   .object({
     username: z.string(),
     current: z.string().min(8, "Password must be at least 8 characters"),
-    new: z.string().min(8, "Password must be at least 8 characters"),
+    // max 64 to avoid bcrypt 72 bytes limit issues
+    new: z
+      .string()
+      .min(8, "Password must be at least 8 characters")
+      .max(64, "Password cannot exceed 64 characters"),
   })
   .refine((data) => data.current !== data.new, {
     message: "New password must be different from current password",

--- a/client/src/app/pages/users/edit.tsx
+++ b/client/src/app/pages/users/edit.tsx
@@ -57,6 +57,7 @@ import { UserType } from "@/lib/types";
 import { useAuth } from "@/providers/auth-provider";
 
 export default function Edit() {
+  // const isDesktop = useMediaQuery("(min-width: 1024px)");
   const [isLoading, setIsLoading] = useState(true);
   const [active, setActive] = useState(false);
   const [role, setRole] = useState("user");
@@ -270,7 +271,7 @@ export default function Edit() {
                 {t("Update user details.")}
               </CardDescription>
             </CardHeader>
-            <UserForm user={user} />
+            <UserForm user={user} isDesktop={true} />
           </Card>
         </TabsContent>
         <TabsContent value="settings" className="h-[500px]">

--- a/client/src/app/pages/users/form.tsx
+++ b/client/src/app/pages/users/form.tsx
@@ -94,12 +94,13 @@ const UserForm = ({
     .refine(
       (data) => {
         if (!user && data.password) {
-          return data.password.length >= 8;
+          // max 64 to avoid bcrypt 72 bytes limit issues
+          return data.password.length >= 8 && data.password.length <= 64;
         }
         return true;
       },
       {
-        message: "Password must be at least 8 characters",
+        message: "Password must be between 8 and 64 characters.",
         path: ["password"],
       }
     );

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -18,6 +18,14 @@ export const registerUser = async (req, res) => {
     );
   }
 
+  // password max length 64 chars -- to avoid bcrypt 72 bytes limit issues
+  if (password.length > 64) {
+    throw new ResponseError(
+      "Password cannot exceed 64 characters",
+      statusCode.BAD_REQUEST
+    );
+  }
+
   await User.create({
     firstName,
     lastName,
@@ -98,6 +106,13 @@ export const updatePassword = async (req, res) => {
     throw new ResponseError("Invalid current password", statusCode.BAD_REQUEST);
   }
 
+  if (newPassword.length > 64) {
+    throw new ResponseError(
+      "Password cannot exceed 64 characters",
+      statusCode.BAD_REQUEST
+    );
+  }
+
   user.password = newPassword;
   await user.save();
   await Session.deleteMany({ user: req.user.id });
@@ -158,6 +173,13 @@ export const checkUsername = async (req, res) => {
 // @desc    Reset a user's password by an administrator
 export const resetPassword = async (req, res) => {
   const user = await User.findById(req.params.userID);
+
+  if (req.body.password.length > 64) {
+    throw new ResponseError(
+      "Password cannot exceed 64 characters",
+      statusCode.BAD_REQUEST
+    );
+  }
 
   user.password = req.body.password;
   await user.save();


### PR DESCRIPTION
avoid bcrypt's 72 byte limit issue

e.g: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1 ` and `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2` can both login to same account